### PR TITLE
fix!: remove `httpClient` field and `close()` method from NuGetResource

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -48,31 +48,31 @@ final class NuGetClient {
 
     final resources = await serviceIndexResource.get();
     final ServiceIndexResponse(
-      packageContentResourceUri: packageContentResourceUrl,
-      packageMetadataResourceUri: packageMetadataResourceUrl,
-      searchAutocompleteResourceUri: searchAutocompleteResourceUrl,
-      searchQueryResourceUri: searchQueryResourceUrl
+      :packageContentResourceUri,
+      :packageMetadataResourceUri,
+      :searchAutocompleteResourceUri,
+      :searchQueryResourceUri
     ) = resources;
 
     // Required resources.
     _resourceCache[PackageContentResource] = PackageContentResource(
       httpClient: _httpClient,
-      resourceUri: packageContentResourceUrl,
+      resourceUri: packageContentResourceUri,
     );
     _resourceCache[PackageMetadataResource] = PackageMetadataResource(
       httpClient: _httpClient,
-      resourceUri: packageMetadataResourceUrl,
+      resourceUri: packageMetadataResourceUri,
     );
     _resourceCache[SearchResource] = SearchResource(
       httpClient: _httpClient,
-      resourceUri: searchQueryResourceUrl,
+      resourceUri: searchQueryResourceUri,
     );
 
     // Optional resources.
-    if (searchAutocompleteResourceUrl != null) {
+    if (searchAutocompleteResourceUri != null) {
       _resourceCache[AutocompleteResource] = AutocompleteResource(
         httpClient: _httpClient,
-        resourceUri: searchAutocompleteResourceUrl,
+        resourceUri: searchAutocompleteResourceUri,
       );
     }
 

--- a/lib/src/resources/autocomplete/autocomplete_resource.dart
+++ b/lib/src/resources/autocomplete/autocomplete_resource.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:http/http.dart' as http;
 import 'package:version/version.dart';
 
 import '../../exception.dart';
@@ -12,7 +13,14 @@ import 'models/autocomplete_package_ids_response.dart';
 /// See also:
 /// https://learn.microsoft.com/nuget/api/search-autocomplete-service-resource
 final class AutocompleteResource extends NuGetResource {
-  AutocompleteResource({required super.resourceUri, super.httpClient});
+  AutocompleteResource({required super.resourceUri, http.Client? httpClient})
+      : httpClient = httpClient ?? http.Client();
+
+  /// The underlying HTTP client used to make requests.
+  final http.Client httpClient;
+
+  /// Closes the underlying HTTP client.
+  void close() => httpClient.close();
 
   /// Retrieves the package IDs that match the [query].
   ///

--- a/lib/src/resources/package_content/package_content_resource.dart
+++ b/lib/src/resources/package_content/package_content_resource.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:http/http.dart' as http;
+
 import '../../exception.dart';
 import '../resource.dart';
 
@@ -9,7 +11,14 @@ import '../resource.dart';
 ///
 /// See https://learn.microsoft.com/nuget/api/package-base-address-resource
 final class PackageContentResource extends NuGetResource {
-  PackageContentResource({required super.resourceUri, super.httpClient});
+  PackageContentResource({required super.resourceUri, http.Client? httpClient})
+      : httpClient = httpClient ?? http.Client();
+
+  /// The underlying HTTP client used to make requests.
+  final http.Client httpClient;
+
+  /// Closes the underlying HTTP client.
+  void close() => httpClient.close();
 
   /// Returns the contents of the package content (`.nupkg`) file for the
   /// package with the [packageId] and [version].

--- a/lib/src/resources/package_metadata/package_metadata_resource.dart
+++ b/lib/src/resources/package_metadata/package_metadata_resource.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
 
+import 'package:http/http.dart' as http;
+
 import '../../exception.dart';
 import '../resource.dart';
 import 'models/registration_index_response.dart';
@@ -11,7 +13,14 @@ import 'models/registration_page_response.dart';
 ///
 /// See https://learn.microsoft.com/nuget/api/registration-base-url-resource
 final class PackageMetadataResource extends NuGetResource {
-  PackageMetadataResource({required super.resourceUri, super.httpClient});
+  PackageMetadataResource({required super.resourceUri, http.Client? httpClient})
+      : httpClient = httpClient ?? http.Client();
+
+  /// The underlying HTTP client used to make requests.
+  final http.Client httpClient;
+
+  /// Closes the underlying HTTP client.
+  void close() => httpClient.close();
 
   /// Retrieves the registration index for the package with the [packageId].
   ///

--- a/lib/src/resources/resource.dart
+++ b/lib/src/resources/resource.dart
@@ -1,21 +1,9 @@
-import 'package:http/http.dart' as http;
-
 /// A base class for all *NuGet* resources.
 abstract class NuGetResource {
-  /// Creates a new instance of the [NuGetResource] class.
-  ///
-  /// * [httpClient]: The HTTP client used to make requests. If `null`, a new
-  /// instance of [http.Client] is created automatically.
-  /// * [resourceUri]: The [Uri] of the *NuGet* resource.
-  NuGetResource({required this.resourceUri, http.Client? httpClient})
-      : httpClient = httpClient ?? http.Client();
-
-  /// The underlying HTTP client used to make requests.
-  final http.Client httpClient;
+  /// Creates a new instance of the [NuGetResource] with the specified
+  /// [resourceUri].
+  NuGetResource({required this.resourceUri});
 
   /// The URI of the *NuGet* resource.
   final Uri resourceUri;
-
-  /// Closes the underlying HTTP client.
-  void close() => httpClient.close();
 }

--- a/lib/src/resources/search/search_resource.dart
+++ b/lib/src/resources/search/search_resource.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:http/http.dart' as http;
 import 'package:version/version.dart';
 
 import '../../exception.dart';
@@ -10,7 +11,14 @@ import 'models/search_response.dart';
 ///
 /// See https://learn.microsoft.com/nuget/api/search-query-service-resource
 final class SearchResource extends NuGetResource {
-  SearchResource({required super.resourceUri, super.httpClient});
+  SearchResource({required super.resourceUri, http.Client? httpClient})
+      : httpClient = httpClient ?? http.Client();
+
+  /// The underlying HTTP client used to make requests.
+  final http.Client httpClient;
+
+  /// Closes the underlying HTTP client.
+  void close() => httpClient.close();
 
   /// Retrieves the packages that match the [query].
   ///

--- a/lib/src/resources/service_index/models/service_index_response.dart
+++ b/lib/src/resources/service_index/models/service_index_response.dart
@@ -89,7 +89,8 @@ extension ServiceIndexResponseHelpers on ServiceIndexResponse {
     final resourceUri = getResourceUri(types);
     if (resourceUri == null) {
       throw NuGetServerException(
-          'The service index does not have a resource named `${types.last}`.');
+        'The service index does not have a resource named `${types.last}`.',
+      );
     }
 
     return resourceUri;

--- a/lib/src/resources/service_index/service_index_resource.dart
+++ b/lib/src/resources/service_index/service_index_resource.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
 
+import 'package:http/http.dart' as http;
+
 import '../../exception.dart';
 import '../resource.dart';
 import 'models/service_index_response.dart';
@@ -12,7 +14,14 @@ final class ServiceIndexResource extends NuGetResource {
   ///
   /// [resourceUri] defaults to [nugetOrgServiceIndex], which is the official
   /// `NuGet.org` service index.
-  ServiceIndexResource({required super.resourceUri, super.httpClient});
+  ServiceIndexResource({required super.resourceUri, http.Client? httpClient})
+      : httpClient = httpClient ?? http.Client();
+
+  /// The underlying HTTP client used to make requests.
+  final http.Client httpClient;
+
+  /// Closes the underlying HTTP client.
+  void close() => httpClient.close();
 
   /// The official `NuGet.org` service index.
   static final nugetOrgServiceIndex =


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the
  title.

  Please look at the following checklist to ensure that your PR can be accepted
  quickly:
-->

## Description

**BREAKING CHANGE:** The `httpClient` field and the `close()` method have been removed from the `NuGetResource` class.

## Related Issue

<!--- Link the relevant issue here -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] 🚀 `feat` – New feature (non-breaking change that adds functionality)
- [x] 🛠️ `fix` – Bug fix (non-breaking change that fixes an issue)
- [x] ❌ `!` – Breaking change (fix or feature that causes existing functionality to change)
- [ ] ⚡ `perf` – Performance improvement
- [ ] 🧹 `refactor` – Code refactor (no functionality change)
- [ ] 📝 `docs` – Documentation update
- [ ] 🎨 `style` – Code style changes (formatting, renaming, etc.)
- [ ] 🧪 `test` – Test update or addition
- [ ] 🔧 `build` – Build related changes
- [ ] ✅ `ci` – CI related changes
- [ ] 🗑️ `chore` – Chore (maintenance, non-production code change)
- [ ] ◀️  `revert` – Revert a previous commit
